### PR TITLE
Dynamic Param switch block fix

### DIFF
--- a/Certificate_Automation/New-CertificateRequest.ps1
+++ b/Certificate_Automation/New-CertificateRequest.ps1
@@ -30,9 +30,9 @@ Param(
 )
     DynamicParam {
         switch ($Source){
-            "$vCenter" {$paramName = "vCenterServer"}
-            "$Hostname" {$paramName = "Hostname"}
-            "$File" {$paramName = "FilePath"}
+            "vCenter" {$paramName = "vCenterServer"}
+            "Hostname" {$paramName = "Hostname"}
+            "File" {$paramName = "FilePath"}
         }
 
         $attributes = New-Object -TypeName System.Management.Automation.ParameterAttribute


### PR DESCRIPTION
The values in the DynamicParam switch block did not match those in the Validated Set. As an example the 'vCenter' string was set as "$vCenter" in the switch block. The '$' characters were removed.